### PR TITLE
feat: Adding capacity to define skilljars in dependency section at plugin level

### DIFF
--- a/src/main/java/com/skillsjars/maven/ExtractMojo.java
+++ b/src/main/java/com/skillsjars/maven/ExtractMojo.java
@@ -2,6 +2,7 @@ package com.skillsjars.maven;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -30,6 +31,9 @@ public class ExtractMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
+    @Parameter(defaultValue = "${mojoExecution}", readonly = true)
+    private MojoExecution mojoExecution;
+
     // Package-private setters for testing
     void setDir(String dir) {
         this.dir = dir;
@@ -41,6 +45,10 @@ public class ExtractMojo extends AbstractMojo {
 
     void setProject(MavenProject project) {
         this.project = project;
+    }
+
+    void setMojoExecution(MojoExecution mojoExecution) {
+        this.mojoExecution = mojoExecution;
     }
 
     private static final String SKILLSJARS_GROUP = "com.skillsjars";
@@ -100,15 +108,31 @@ public class ExtractMojo extends AbstractMojo {
 
     private Set<Artifact> findSkillsJars(Set<String> allowedScopes) {
         Set<Artifact> result = new HashSet<>();
-        Set<Artifact> artifacts = project.getArtifacts();
-        
-        for (Artifact artifact : artifacts) {
-            if (SKILLSJARS_GROUP.equals(artifact.getGroupId()) && 
+
+        // Collect from project dependencies (compile, provided, runtime, test, system)
+        Set<Artifact> projectArtifacts = project.getArtifacts();
+        for (Artifact artifact : projectArtifacts) {
+            if (SKILLSJARS_GROUP.equals(artifact.getGroupId()) &&
                 allowedScopes.contains(artifact.getScope())) {
                 result.add(artifact);
             }
         }
-        
+
+        // Collect from plugin dependencies (<plugin><dependencies>...</dependencies></plugin>)
+        if (mojoExecution != null) {
+            var mojoDescriptor = mojoExecution.getMojoDescriptor();
+            if (mojoDescriptor != null) {
+                var pluginDescriptor = mojoDescriptor.getPluginDescriptor();
+                if (pluginDescriptor != null && pluginDescriptor.getArtifacts() != null) {
+                    for (Artifact artifact : pluginDescriptor.getArtifacts()) {
+                        if (SKILLSJARS_GROUP.equals(artifact.getGroupId())) {
+                            result.add(artifact);
+                        }
+                    }
+                }
+            }
+        }
+
         return result;
     }
 

--- a/src/test/java/com/skillsjars/maven/ExtractMojoTest.java
+++ b/src/test/java/com/skillsjars/maven/ExtractMojoTest.java
@@ -3,7 +3,10 @@ package com.skillsjars.maven;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.project.MavenProject;
 import org.junit.After;
 import org.junit.Before;
@@ -14,6 +17,7 @@ import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -178,6 +182,47 @@ public class ExtractMojoTest {
         } catch (MojoExecutionException e) {
             assertTrue(e.getMessage().contains("conflict"));
         }
+    }
+
+    @Test
+    public void testExtractSkillsJarFromPluginDependencies() throws Exception {
+        File jarFile = createTestSkillsJar("plugin-skill", "META-INF/skills/");
+        File outputDir = new File(testDir, "output");
+
+        Artifact pluginArtifact = new DefaultArtifact(
+            "com.skillsjars",
+            "skill2",
+            "1.0.0",
+            Artifact.SCOPE_COMPILE,
+            "jar",
+            null,
+            new DefaultArtifactHandler("jar")
+        );
+        pluginArtifact.setFile(jarFile);
+
+        PluginDescriptor pluginDescriptor = new PluginDescriptor();
+        pluginDescriptor.setArtifacts(Collections.singletonList(pluginArtifact));
+
+        MojoDescriptor mojoDescriptor = new MojoDescriptor();
+        mojoDescriptor.setPluginDescriptor(pluginDescriptor);
+
+        MojoExecution mojoExecution = new MojoExecution(mojoDescriptor);
+
+        ExtractMojo mojo = new ExtractMojo();
+        mojo.setDir(outputDir.getAbsolutePath());
+
+        MavenProject project = new MavenProject();
+        project.setArtifacts(new HashSet<>());
+        mojo.setProject(project);
+        mojo.setMojoExecution(mojoExecution);
+
+        mojo.execute();
+
+        Path extractedSkillMd = Paths.get(outputDir.getAbsolutePath(), "skillsjars__org__repo__skill", "SKILL.md");
+        assertTrue("SKILL.md from plugin dependency should exist", Files.exists(extractedSkillMd));
+
+        Path extractedFile = Paths.get(outputDir.getAbsolutePath(), "skillsjars__org__repo__skill", "test.txt");
+        assertTrue("Extracted file from plugin dependency should exist", Files.exists(extractedFile));
     }
 
     private File createTestSkillsJar(String name) throws Exception {


### PR DESCRIPTION
Hi,

Currently the skilljars are defined at build level:

```xml
    <dependencies>
        <dependency>
            <groupId>com.skillsjars</groupId>
            <artifactId>anthropics__skills__pdf</artifactId>
            <version>2026_02_06-1ed29a0</version>
        </dependency>
        <dependency>
            <groupId>com.skillsjars</groupId>
            <artifactId>sivaprasadreddy__sivalabs-agent-skills__spring-boot</artifactId>
            <version>2026_02_23-dba3310</version>
        </dependency>
    </dependencies>
```

But if you don´t use `JVM Agents` in combination with skills, maybe it couldbe safer to use provided scope:

```xml
    <dependencies>
        <dependency>
            <groupId>com.skillsjars</groupId>
            <artifactId>anthropics__skills__pdf</artifactId>
            <version>2026_02_06-1ed29a0</version>
            <scope>provided</scope>
        </dependency>
        <dependency>
            <groupId>com.skillsjars</groupId>
            <artifactId>sivaprasadreddy__sivalabs-agent-skills__spring-boot</artifactId>
            <version>2026_02_23-dba3310</version>
            <scope>provided</scope>
        </dependency>
    </dependencies>
```

To avoid that skills appear in the jar by accident.

Maybe, it could be safer to define the `Skilljars` at plugin level avoiding any side-effect in the long term:

```xml
    <build>
        <plugins>
            <plugin>
                <groupId>com.skillsjars</groupId>
                <artifactId>maven-plugin</artifactId>
                <version>0.0.3-SNAPSHOT</version>
                
                <dependencies>
                    <dependency>
                        <groupId>com.skillsjars</groupId>
                        <artifactId>jabrena__cursor-rules-java__110-java-maven-best-practices</artifactId>
                        <version>2026_02_23-96a0bd2</version>
                    </dependency>
                </dependencies>
                
            </plugin>
        </plugins>
    </build>
```

This PR, add that capacity. I tested with the example using the goal provided in the documentation:

```bash
./mvnw skillsjars:extract -Ddir=.kiro/skills
```

Juan Antonio
